### PR TITLE
Add ToString to IBaseModelList.

### DIFF
--- a/SpaceX-API/Models/Common/BaseModel.pas
+++ b/SpaceX-API/Models/Common/BaseModel.pas
@@ -21,6 +21,7 @@ type
   IBaseModelList = interface(IInterfaceList) ['{A88A3F2B-21CB-4DE3-95D6-557FC4168032}']
     function NewItem: IBaseModel;
     function GetItem(Idx: Integer): IBaseModel;
+    function ToString(const LineBreak: string = LineEnding): string;
     property Items[Idx: Integer]: IBaseModel read GetItem; default;
   end;
 
@@ -35,15 +36,19 @@ type
   TBaseModelList = class(TInterfaceList, IBaseModelList)
     function NewItem: IBaseModel; virtual; abstract;
     function GetItem(Idx: Integer): IBaseModel;
+    function ToString(const LineBreak: string = LineEnding): string; overload;
   end;
 
   { TBaseModelEnumerator }
 
   TBaseModelEnumerator = class
+  public
     FCurrent : IBaseModel;
     FList: IBaseModelList;
     FIdx : Integer;
+  public
     function MoveNext : Boolean;
+  public
     property Current : IBaseModel read FCurrent;
   end;
 
@@ -83,6 +88,19 @@ end;
 function TBaseModelList.GetItem(Idx: Integer): IBaseModel;
 begin
   Result := Self.Get(Idx) as IBaseModel;
+end;
+
+function TBaseModelList.ToString(const LineBreak: string): string;
+var
+  StrList: TStringList;
+  Model: IBaseModel;
+begin
+  StrList := TStringList.Create;
+  StrList.TrailingLineBreak := False;
+  StrList.LineBreak := LineBreak;
+  for Model in Self do
+    StrList.Add(Model.ToString);
+  Result := StrList.Text;
 end;
 
 end.

--- a/SpaceX-API/Models/Crew/Crew.pas
+++ b/SpaceX-API/Models/Crew/Crew.pas
@@ -75,8 +75,6 @@ type
     FName: string;
     FStatus: string;
     FWikipedia: string;
-    constructor Create;
-    destructor destroy;
   private
     function GetAgency: string;
     function GetId: string;
@@ -101,6 +99,9 @@ type
     procedure SetWikipedia(AValue: Variant);
   public
     function ToString(): string; override;
+  public
+    constructor Create;
+    destructor Destroy; override;
   published
     property agency: Variant write SetAgency;
     property id: Variant write SetId;
@@ -226,14 +227,6 @@ end;
 procedure TCrew.SetLaunches(AValue: TStringList);
 begin
   FLaunches := AValue;
-end;
-
-procedure TCrew.SetLaunchesId(AValue: Variant);
-begin
-  if VarIsNull(AValue) then begin
-    FLaunchesId := TStringList.Create;
-  end else if VarIsStr(AValue) then
-    FLaunchesId.AddDelimitedtext(AValue);
 end;
 
 procedure TCrew.SetName(AValue: string);

--- a/SpaceX-API/Models/Launches/LaunchCore.pas
+++ b/SpaceX-API/Models/Launches/LaunchCore.pas
@@ -315,13 +315,13 @@ begin
     , [
       GetCoreId,
       GetFlight,
-      BoolToStr(GetGridfins),
+      BoolToStr(GetGridfins, True),
       GetLandpadId,
-      GetLandingAttempt,
-      GetLandingSuccess,
+      BoolToStr(GetLandingAttempt, True),
+      BoolToStr(GetLandingSuccess, True),
       GetLandingType,
-      GetLegs,
-      GetReused
+      BoolToStr(GetLegs, True),
+      BoolToStr(GetReused, True)
     ]);
 end;
 

--- a/SpaceX-API/Models/Rockets/RocketPotentialPayloadWeight.pas
+++ b/SpaceX-API/Models/Rockets/RocketPotentialPayloadWeight.pas
@@ -84,7 +84,6 @@ type
 
   TRocketPotentialPayloadWeightList = class(TBaseModelList, IRocketPotentialPayloadWeightList)
     function NewItem: IBaseModel; override;
-    function ToString: string; override;
   end;
 
 function NewRocketPotentialPayloadWeight: IRocketPotentialPayloadWeight;
@@ -116,15 +115,6 @@ end;
 function TRocketPotentialPayloadWeightList.NewItem: IBaseModel;
 begin
   Result := NewRocketPotentialPayloadWeight;
-end;
-
-function TRocketPotentialPayloadWeightList.ToString: string;
-var
-  RocketPotentialPayloadWeight: IRocketPotentialPayloadWeight;
-begin
-  for RocketPotentialPayloadWeight in Self do begin
-    RocketPotentialPayloadWeight.ToString;
-  end;
 end;
 
 { TRocketPotentialPayloadWeight }


### PR DESCRIPTION
Move constructor/destructor for TCrew from private to public.
Fix booleans in ToString for LaunchCore.
Populate Cores in Launch object.
Use BoolToStr(bool, True) to print True/False, defaults to printing an integer.